### PR TITLE
Proper model name to use pre-trained weight

### DIFF
--- a/model/dolg.py
+++ b/model/dolg.py
@@ -90,7 +90,7 @@ class DolgNet(LightningModule):
     def __init__(self, input_dim, hidden_dim, output_dim, num_of_classes):
         super().__init__()
         self.cnn = timm.create_model(
-            'resnet101',
+            'tv_resnet101',
             pretrained=True,
             features_only=True,
             in_chans=input_dim,


### PR DESCRIPTION
According to https://github.com/rwightman/pytorch-image-models/issues/412 , the model `resnet101` from pytorch-image-models(timm) doesn't provide a pre-trained weight. This change allows using pre-trained weight, following the paper's model setup. Eventually, the DOLG model converges faster.